### PR TITLE
Updated check_stuff.pl, README

### DIFF
--- a/README
+++ b/README
@@ -11,9 +11,22 @@ stable when it reaches version 1.0.**
 Installing
 ----------
 
-You may need some prerequisites first. If you're on RHEL/Cent, it would be:
+You may need some prerequisites first. If you're on CentOS/RHEL, make sure to 
+install CPAN and use those packages, since yum no longer supports some 
+required packages.   
+For CentOS 6/7:
 
-    yum install -y perl-devel perl-Class-Accessor perl-Config-Tiny perl-Math-Calc-Units
+    yum install -y perl-devel cpan make
+    cpan Test::More
+    cpan Params::Validate Math::Calc::Units Class::Accessor::Fast Config::Tiny
+
+For Debian 7+/Ubuntu 14.04+:
+
+    apt-get install make libperl-dev libparams-validate-perl libmath-calc-units-perl libclass-accessor-perl libconfig-tiny-perl
+
+For Fedora 25+:
+
+    dnf install -y make perl-devel 'perl(Params::Validate)' 'perl(Math::Calc::Units)' 'perl(Class::Accessor::Fast)' 'perl(Config::Tiny)' 'perl(Test::More)'
 
 To install this module type the following:
 
@@ -39,5 +52,3 @@ Copyright (C) 2006-2017 by Nagios Plugin Development Team
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.8.4 or,
 at your option, any later version of Perl 5 you may have available.
-
-

--- a/t/check_stuff.pl
+++ b/t/check_stuff.pl
@@ -16,7 +16,11 @@
 use strict;
 use warnings;
 
-use Nagios::Monitoring::Plugin ;
+use File::Basename qw(dirname);
+use Cwd  qw(abs_path);
+use lib dirname(dirname abs_path $0) . '/lib';
+
+use Nagios::Monitoring::Plugin;
 
 use vars qw($VERSION $PROGNAME  $verbose $warn $critical $timeout $result);
 $VERSION = '1.0';


### PR DESCRIPTION
check_stuff now pulls in the local Nagios library, so 'perl Makefile.PL && make && make test && make install' works now.

Updated README with correct packages. Installation was tested on the following distros:
CentOS 6x64 Minimal
CentOS 7 Minimal
Fedora 25 Workstation
Fedora Rawhide Minimal (for an install on 6/22/17)
Debian 7 Minimal
Debian 8 Minimal
Debian 9 w/ Desktop Manager
Ubuntu 14.04
Ubuntu 16.04
Ubuntu 17.04

I haven't made another plugin yet as @hedenface suggested, but I won't have time to do that until Tuesday and in the meantime I'd rather have the plugin library make properly.